### PR TITLE
:bug: Unable to Destroy Create Failed Bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,7 @@
+# v0.0.2
+* Fixes bug where a bucket in a failed state
+  (bucket was not created) exists in a stack
+  and this causes the callback to fail.
+
 # v0.0.1
 * Initial release

--- a/lib/sfn-bucketpurge/bucket_purge.rb
+++ b/lib/sfn-bucketpurge/bucket_purge.rb
@@ -11,6 +11,10 @@ module Sfn
           rescue
             next
           end
+          if resource.name.nil?
+            ui.info "Found a failed resource, whose name is nil, skipping..."
+            next
+          end
           next unless resource.is_a?(Miasma::Models::Storage::Bucket)
           files = resource.files.all
           next if files.empty?

--- a/lib/sfn-bucketpurge/version.rb
+++ b/lib/sfn-bucketpurge/version.rb
@@ -1,3 +1,3 @@
 module SfnBucketPurge
-  VERSION = Gem::Version.new('0.0.1')
+  VERSION = Gem::Version.new('0.0.2')
 end


### PR DESCRIPTION
- Fixes bug https://github.com/sparkleformation/sfn-bucketpurge/issues/2
  where the callback was unable to destroy a stack that contains
  a bucket in the 'CREATE_FAILED' state.

To Reproduce:

1. Create a stack with an improper bucket name.
  ```
  SparkleFormation.new(:bucket_test, :provider => :aws) do

    dynamic!(:bucket, :bucket_one) do
      depends_on 'Bucket2Bucket'
      properties do
        bucket_name 'Bad-bucketname2334'
      end
    end

    dynamic!(:bucket, :bucket2) do
      properties do
        bucket_name 'test122354'
      end
    end
  end
  ```
2. Try to destroy the stack with sfn_bucketpurge 0.0.1 enabled, and find
   the following error along with remaining stack.
  ```
  [ERROR]: no implicit conversion of nil into String
  ```